### PR TITLE
Improve messaging for SDK resolution failures

### DIFF
--- a/extension/lsp/lsp.ts
+++ b/extension/lsp/lsp.ts
@@ -204,7 +204,6 @@ export class MojoLSPManager extends DisposableContext {
     const sdk = await this.envManager.getActiveSDK();
 
     if (!sdk) {
-      await this.envManager.showInstallWarning();
       return;
     }
 


### PR DESCRIPTION
Previously we would report a single generic message if any exception was thrown during the SDK loading process. This PR changes that; we now report different messages depending on what went wrong. This should help users as well as allow us to debug SDK resolution failures more effectively.