### PR TITLE
Fix CONDA_PREFIX for RPC debug path

### DIFF
--- a/extension/debug/debug.ts
+++ b/extension/debug/debug.ts
@@ -87,9 +87,14 @@ async function findSDKForDebugConfiguration(
   envManager: PythonEnvironmentManager,
 ): Promise<Optional<SDK>> {
   if (config.modularHomePath !== undefined) {
+    const homePath = config.modularHomePath.replace(/\/+$/, '');
+    const prefixPath = homePath.endsWith('/share/max')
+      ? homePath.replace(/\/share\/max$/, '')
+      : undefined;
     return envManager.createSDKFromHomePath(
       SDKKind.Custom,
-      config.modularHomePath,
+      homePath,
+      prefixPath,
     );
   }
   return envManager.getActiveSDK();


### PR DESCRIPTION
prefixPath was not being passed properly when debugging via RPC, which causes CONDA_PREFIX to be empty and an incorrect path used when attempting to launch mojo-lldb-dap. This breaks debugging via mojo debug --vscode in conda environments.