### PR TITLE
Fixed build ci job not respecting npm version bump

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,10 @@ on:
       - main
 
   workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
 
 jobs:
   build:
@@ -23,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,6 +45,7 @@ jobs:
 
     outputs:
       version: ${{ steps.bump.outputs.version }}
+      commit_sha: ${{ steps.get_sha.outputs.sha }}
 
     steps:
       - name: Setup Node
@@ -74,9 +75,15 @@ jobs:
           export VERSION=$(jq -r '.version' package.json)
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
+      - name: Get new commit SHA
+        id: get_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
   build:
     needs: [version]
     uses: ./.github/workflows/build.yaml
+    with:
+      ref: ${{ needs.version.outputs.commit_sha || github.sha }}
 
   publish:
     name: Publish extension
@@ -90,6 +97,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ needs.version.outputs.commit_sha || github.sha }}
 
       - uses: ./.github/actions/setup
 


### PR DESCRIPTION
The build ci job would checkout the original commit, unaware of the new commit pushed by the Increment version job. Now the commit sha is passed on to be properly respected if present.