### PR TITLE
Filter out diagnostics if they are in docsstring

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,12 @@
             "type": "string"
           }
         },
+        "mojo.lsp.suppress.diagnostics.in.docstring": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "Suppress warnings and errors in docstring."
+        },
         "mojo.formatting.args": {
           "scope": "resource",
           "type": "array",


### PR DESCRIPTION
This PR allows suppression of warnings and errors in docstrings. Although this is generally useful to see warnings and errors in docstrings snippets in some cases, making a fully correct code in docstring snippets means clutter which obscures the example you want to highlight in the docstring. A good example is the mojo standard library, many files have warning and errors in docstrings, which introduces noise and does not help.

The PR introduces a config entry for suppression which defaults to false, so the default behavior is same as we have now.

### Alternative consideration: 
- we could also not fully suppress the diagnostics but set warning and errors in doctstring to information level.
- It would be great if we could send a flag to the language server to not emit the diagnostics for the docstrings, which would reduce compute on extension and language server side.