### PR TITLE
Cache the active SDK to avoid repeated queries

### DIFF
--- a/extension/pyenv.ts
+++ b/extension/pyenv.ts
@@ -149,6 +149,7 @@ export class PythonEnvironmentManager extends DisposableContext {
   private envChangeEmitter: vscode.EventEmitter<void>;
   private displayedSDKError: boolean = false;
   private lastLoadedEnv: string | undefined = undefined;
+  private activeSDK: SDK | undefined = undefined;
 
   constructor(logger: Logger, reporter: TelemetryReporter) {
     super();
@@ -178,8 +179,8 @@ export class PythonEnvironmentManager extends DisposableContext {
     }
   }
 
-  /// Load the active SDK from the currently active Python environment, or undefined if one is not present.
-  public async getActiveSDK(): Promise<SDK | undefined> {
+  /// Finds the active SDK from the currently active Python environment, or undefined if one is not present.
+  public async findActiveSDK(): Promise<SDK | undefined> {
     assert(this.api !== undefined);
     // Prioritize retrieving a monorepo SDK over querying the environment.
     const monorepoSDK = await this.tryGetMonorepoSDK();
@@ -225,6 +226,15 @@ export class PythonEnvironmentManager extends DisposableContext {
       );
       return this.createSDKFromWheelEnv(env);
     }
+  }
+
+  /// Load the active SDK from the currently active Python environment, or undefined if one is not present.
+  public async getActiveSDK(): Promise<SDK | undefined> {
+    if (this.activeSDK) {
+      return this.activeSDK;
+    }
+    this.activeSDK = await this.findActiveSDK();
+    return this.activeSDK;
   }
 
   private async displaySDKError(message: string) {


### PR DESCRIPTION
Currently the extension tries to find the SDK path at each event. As a result you get

```
["INFO" - 6:50:06 PM] Found SDK with version 0.0.0
["INFO" - 6:50:06 PM] Monorepo SDK found, prioritizing that over Python environment.
["INFO" - 6:50:08 PM] Found SDK with version 0.0.0
["INFO" - 6:50:08 PM] Monorepo SDK found, prioritizing that over Python environment.
["INFO" - 6:57:21 PM] Found SDK with version 0.0.0
["INFO" - 6:57:21 PM] Monorepo SDK found, prioritizing that over Python environment.
["INFO" - 6:57:21 PM] Found SDK with version 0.0.0
["INFO" - 6:57:21 PM] Monorepo SDK found, prioritizing that over Python environment.

```

and it slows down every operation. This caches the SDK path if defined so it's persistent across the session