### PR TITLE
Added an initial CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# GitHub Actions workflows and configuration
+/.github/workflows/ @modular/mojo-tooling
+/.github/actions/ @modular/mojo-tooling
+
+# Package dependencies
+/package.json @modular/mojo-tooling
+/package-lock.json @modular/mojo-tooling
+/lsp-proxy/package.json @modular/mojo-tooling
+/lsp-proxy/package-lock.json @modular/mojo-tooling


### PR DESCRIPTION
This initial CODEOWNERS file should serve to protect the GitHub Actions workflow files and other package dependencies from being edited unnecessarily.