### PR TITLE
added explicit permissions for all workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,9 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build extension

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -20,10 +20,10 @@ on:
 
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
-  actions: write
-  contents: read
-  pull-requests: write
-  statuses: write
+  actions: write # Required to update workflow run status
+  contents: read # Required to read repository code
+  pull-requests: write # Required to comment on PRs with CLA instructions
+  statuses: write # Required to set commit status checks
 
 jobs:
   CLAAssistant:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,13 +36,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read # set a default which is overruled at job level
+
 jobs:
   version:
     name: Increment version
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: write # Required for version bumps
 
     defaults:
       run:
@@ -94,6 +97,8 @@ jobs:
     name: Publish extension
     runs-on: ubuntu-latest
     needs: [version, build]
+    permissions:
+      contents: write # Needed to create GitHub releases
 
     defaults:
       run:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Each GitHub Actions workflow should now have an explicit permission listed, in the case of a workflow needing write access an explanation for this is provided in a comment.