### PR TITLE
Make Prettier / ESLint ignore GitHub workflows and build output

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+# Build outputs
+out/
+lsp-proxy/out/
+node_modules/
+
+# GitHub Actions workflows
+.github/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,7 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
-    ignores: ['out/**', 'lsp-proxy/out/**'],
+    ignores: ['out/**', 'lsp-proxy/out/**', '.github/**'],
   },
   eslint.configs.recommended,
   tseslint.configs.recommended,


### PR DESCRIPTION
The linting workflow will pick up errors in things like GitHub Actions workflows that come from templates. Better to make some good ignore rules.