### PR TITLE
use a PAT for the deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
We need to use a PAT here because we've locked down main.