### PR TITLE
Make ms-python.python a soft dependency

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -21,5 +21,6 @@ export default defineConfig([
     label: 'pixi',
     workspaceFolder: 'fixtures/pixi-workspace/',
     files: 'out/**/*.test.pixi.js',
+    installExtensions: ['ms-python.python'],
   },
 ]);

--- a/README.md
+++ b/README.md
@@ -25,18 +25,21 @@ This VS Code extension from the Modular team adds support for the
 
 ### Mojo SDK resolution
 
-The extension relies on the Python extension for locating your Python
-environment. In some cases, this appears to default to your globally-installed
-environment, even when a virtual environment exists.
-
 When the extension detects a Mojo project (a workspace containing `.mojo`
 files, or with a `.mojo` file open), the SDK status appears in the bottom-left
 status bar, showing details of the detected SDK or a clickable notice if no
 SDK was detected.
 
+To discover SDKs installed in pixi or wheel-based Python environments, the
+extension uses the [Python extension for VS
+Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python).
+If the Python extension is not installed, the status bar will prompt you to
+install it; clicking the prompt opens it in the marketplace.
+
 If the Mojo extension cannot find your SDK installation, try invoking the
-`Python: Select Interpreter` command and selecting your virtual
-environment.
+`Python: Select Interpreter` command and selecting the environment that
+contains your Mojo SDK. In some cases, the Python extension defaults to your
+globally-installed environment even when a workspace-local one exists.
 
 ## Debugger
 

--- a/README.md
+++ b/README.md
@@ -30,16 +30,47 @@ files, or with a `.mojo` file open), the SDK status appears in the bottom-left
 status bar, showing details of the detected SDK or a clickable notice if no
 SDK was detected.
 
-To discover SDKs installed in pixi or wheel-based Python environments, the
-extension uses the [Python extension for VS
-Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python).
+The extension resolves the active SDK in this priority order:
+
+1. **`mojo.sdk.path` setting** — if set, the extension uses this path as an
+   explicit override and does not fall back to auto-detection. See below.
+2. **Monorepo SDK** — a `.derived/` directory in the open workspace folder.
+3. **Python environment** — discovered via the [Python extension for VS
+   Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python),
+   used to locate SDKs installed in pixi or wheel-based environments.
+
 If the Python extension is not installed, the status bar will prompt you to
 install it; clicking the prompt opens it in the marketplace.
+
+#### `mojo.sdk.path` override
+
+For environments where the Python extension is unavailable or auto-detection
+picks the wrong environment, you can set `mojo.sdk.path` to point at a Mojo
+SDK directly. The setting is available in both the Settings UI and
+`settings.json`, and can be set at either user or workspace scope — workspace
+scope is usually the right choice, since different projects typically use
+different SDKs.
+
+The value must be an absolute path to an environment root:
+
+- **For pixi or conda installs**, point to the environment root that contains
+  `share/max/modular.cfg` — for example,
+  `/path/to/workspace/.pixi/envs/default`.
+- **For wheel installs**, point to the environment root that contains
+  `bin/mojo` and `lib/python*/site-packages/modular/` — for example,
+  `/path/to/.venv`.
+
+When set, this override beats every other detection source. If the path is
+invalid, the extension will surface an error in the status bar rather than
+silently falling back to auto-detection.
+
+#### Troubleshooting
 
 If the Mojo extension cannot find your SDK installation, try invoking the
 `Python: Select Interpreter` command and selecting the environment that
 contains your Mojo SDK. In some cases, the Python extension defaults to your
-globally-installed environment even when a workspace-local one exists.
+globally-installed environment even when a workspace-local one exists. If
+that doesn't help, set `mojo.sdk.path` directly.
 
 ## Debugger
 

--- a/extension/extension.ts
+++ b/extension/extension.ts
@@ -86,10 +86,14 @@ Activating the Mojo Extension
       const updateStatusBar = async () => {
         statusBar.showLoading();
         const sdk = await this.pyenvManager!.findActiveSDK();
-        const reason =
-          !sdk && !this.pyenvManager!.isPythonExtensionAvailable()
-            ? 'no-python-extension'
-            : undefined;
+        let reason;
+        if (!sdk) {
+          if (this.pyenvManager!.getOverridePathState() === 'invalid') {
+            reason = 'invalid-sdk-override' as const;
+          } else if (!this.pyenvManager!.isPythonExtensionAvailable()) {
+            reason = 'no-python-extension' as const;
+          }
+        }
         statusBar.update(sdk, reason);
       };
 
@@ -103,7 +107,7 @@ Activating the Mojo Extension
 
       this.pushSubscription(
         await configWatcher.activate({
-          settings: ['SDK.additionalSDKs'],
+          settings: ['sdk.path'],
         }),
       );
 

--- a/extension/extension.ts
+++ b/extension/extension.ts
@@ -86,7 +86,11 @@ Activating the Mojo Extension
       const updateStatusBar = async () => {
         statusBar.showLoading();
         const sdk = await this.pyenvManager!.findActiveSDK();
-        statusBar.update(sdk);
+        const reason =
+          !sdk && !this.pyenvManager!.isPythonExtensionAvailable()
+            ? 'no-python-extension'
+            : undefined;
+        statusBar.update(sdk, reason);
       };
 
       this.pushSubscription(

--- a/extension/pyenv.ts
+++ b/extension/pyenv.ts
@@ -15,7 +15,6 @@ import * as vscode from 'vscode';
 import * as ini from 'ini';
 import { DisposableContext } from './utils/disposableContext';
 import { PythonExtension, ResolvedEnvironment } from '@vscode/python-extension';
-import assert from 'assert';
 import { Logger } from './logging';
 import path from 'path';
 import * as util from 'util';
@@ -160,7 +159,15 @@ export class PythonEnvironmentManager extends DisposableContext {
   }
 
   public async init() {
-    this.api = await PythonExtension.api();
+    try {
+      this.api = await PythonExtension.api();
+    } catch (e) {
+      this.logger.warn(
+        'The Python extension is not installed. ' +
+          'Install the Python extension (ms-python.python) to enable automatic SDK discovery.',
+      );
+      return;
+    }
     this.pushSubscription(
       this.api.environments.onDidChangeActiveEnvironmentPath((p) =>
         this.handleEnvironmentChange(p.path),
@@ -181,7 +188,16 @@ export class PythonEnvironmentManager extends DisposableContext {
 
   /// Finds the active SDK from the currently active Python environment, or undefined if one is not present.
   public async findActiveSDK(): Promise<SDK | undefined> {
-    assert(this.api !== undefined);
+    if (!this.api) {
+      this.logger.error(
+        'Cannot discover SDK: the Python extension (ms-python.python) is not installed.',
+      );
+      await this.displaySDKError(
+        'The Python extension (ms-python.python) is required for automatic Mojo SDK discovery. ' +
+          'Please install it and restart the extension.',
+      );
+      return undefined;
+    }
     // Prioritize retrieving a monorepo SDK over querying the environment.
     const monorepoSDK = await this.tryGetMonorepoSDK();
 

--- a/extension/pyenv.ts
+++ b/extension/pyenv.ts
@@ -159,13 +159,29 @@ export class PythonEnvironmentManager extends DisposableContext {
   }
 
   public async init() {
-    try {
-      this.api = await PythonExtension.api();
-    } catch (e) {
+    await this.tryInitApi();
+    // Watch for the Python extension being installed/enabled mid-session so
+    // we can pick it up without requiring a window reload.
+    this.pushSubscription(
+      vscode.extensions.onDidChange(() => this.handleExtensionChange()),
+    );
+  }
+
+  private async tryInitApi() {
+    if (this.api) {
+      return;
+    }
+    if (!vscode.extensions.getExtension('ms-python.python')) {
       this.logger.warn(
         'The Python extension is not installed. ' +
           'Install the Python extension (ms-python.python) to enable automatic SDK discovery.',
       );
+      return;
+    }
+    try {
+      this.api = await PythonExtension.api();
+    } catch (e) {
+      this.logger.warn('Failed to load the Python extension API:', e);
       return;
     }
     this.pushSubscription(
@@ -173,6 +189,24 @@ export class PythonEnvironmentManager extends DisposableContext {
         this.handleEnvironmentChange(p.path),
       ),
     );
+  }
+
+  private async handleExtensionChange() {
+    if (this.api) {
+      return;
+    }
+    if (!vscode.extensions.getExtension('ms-python.python')) {
+      return;
+    }
+    this.logger.info(
+      'Python extension became available, initializing SDK discovery.',
+    );
+    await this.tryInitApi();
+    if (this.api) {
+      // Reset error gating and notify subscribers so the status bar refreshes.
+      this.displayedSDKError = false;
+      this.envChangeEmitter.fire();
+    }
   }
 
   private async handleEnvironmentChange(newEnv: string) {
@@ -186,19 +220,16 @@ export class PythonEnvironmentManager extends DisposableContext {
     }
   }
 
+  /// Whether the Python extension API is available. Used by the status bar to
+  /// distinguish "no SDK found" from "Python extension not installed".
+  public isPythonExtensionAvailable(): boolean {
+    return this.api !== undefined;
+  }
+
   /// Finds the active SDK from the currently active Python environment, or undefined if one is not present.
   public async findActiveSDK(): Promise<SDK | undefined> {
-    if (!this.api) {
-      this.logger.error(
-        'Cannot discover SDK: the Python extension (ms-python.python) is not installed.',
-      );
-      await this.displaySDKError(
-        'The Python extension (ms-python.python) is required for automatic Mojo SDK discovery. ' +
-          'Please install it and restart the extension.',
-      );
-      return undefined;
-    }
     // Prioritize retrieving a monorepo SDK over querying the environment.
+    // This path doesn't require the Python extension.
     const monorepoSDK = await this.tryGetMonorepoSDK();
 
     if (monorepoSDK) {
@@ -206,6 +237,13 @@ export class PythonEnvironmentManager extends DisposableContext {
         'Monorepo SDK found, prioritizing that over Python environment.',
       );
       return monorepoSDK;
+    }
+
+    if (!this.api) {
+      this.logger.warn(
+        'Cannot discover SDK: the Python extension (ms-python.python) is not installed.',
+      );
+      return undefined;
     }
 
     const envPath = this.api.environments.getActiveEnvironmentPath();

--- a/extension/pyenv.ts
+++ b/extension/pyenv.ts
@@ -24,7 +24,8 @@ import {
 } from 'child_process';
 import { Memoize } from 'typescript-memoize';
 import { TelemetryReporter } from './telemetry';
-import { fileExists } from './utils/files';
+import { directoryExists, fileExists } from './utils/files';
+import * as config from './utils/config';
 const execFile = util.promisify(callbackExecFile);
 const exec = util.promisify(callbackExec);
 
@@ -140,6 +141,8 @@ class HomeSDK extends SDK {
   }
 }
 
+export type OverridePathState = 'unset' | 'valid' | 'invalid';
+
 export class PythonEnvironmentManager extends DisposableContext {
   private api: PythonExtension | undefined = undefined;
   private logger: Logger;
@@ -149,6 +152,7 @@ export class PythonEnvironmentManager extends DisposableContext {
   private displayedSDKError: boolean = false;
   private lastLoadedEnv: string | undefined = undefined;
   private activeSDK: SDK | undefined = undefined;
+  private overridePathState: OverridePathState = 'unset';
 
   constructor(logger: Logger, reporter: TelemetryReporter) {
     super();
@@ -226,10 +230,29 @@ export class PythonEnvironmentManager extends DisposableContext {
     return this.api !== undefined;
   }
 
-  /// Finds the active SDK from the currently active Python environment, or undefined if one is not present.
+  /// State of the `mojo.sdk.path` override setting. Used by the status bar to
+  /// distinguish "user set an invalid override path" from other failure modes.
+  public getOverridePathState(): OverridePathState {
+    return this.overridePathState;
+  }
+
+  /// Finds the active SDK, in priority order:
+  /// 1. `mojo.sdk.path` override (if set; fails loudly without falling back)
+  /// 2. Monorepo `.derived/` SDK
+  /// 3. SDK from the active Python extension environment
   public async findActiveSDK(): Promise<SDK | undefined> {
-    // Prioritize retrieving a monorepo SDK over querying the environment.
-    // This path doesn't require the Python extension.
+    // 1. User-supplied override path beats every other source. If it's set
+    // but doesn't resolve, do NOT fall back — that would silently violate
+    // the override semantics. The status bar surfaces the failure instead.
+    const overrideSDK = await this.tryGetOverrideSDK();
+    if (overrideSDK) {
+      return overrideSDK;
+    }
+    if (this.overridePathState === 'invalid') {
+      return undefined;
+    }
+
+    // 2. Monorepo SDK — works without the Python extension.
     const monorepoSDK = await this.tryGetMonorepoSDK();
 
     if (monorepoSDK) {
@@ -309,11 +332,28 @@ export class PythonEnvironmentManager extends DisposableContext {
   private async createSDKFromWheelEnv(
     env: ResolvedEnvironment,
   ): Promise<SDK | undefined> {
-    const binPath = path.join(env.executable.sysPrefix, 'bin');
-    const libPath = path.join(
+    return this.createSDKFromWheelLayout(
       env.executable.sysPrefix,
+      env.version!.major,
+      env.version!.minor,
+      SDKKind.Environment,
+    );
+  }
+
+  /// Create an SDK from a wheel-style layout rooted at `sysPrefix`, given
+  /// a known Python major/minor version. Used both for Python-extension envs
+  /// and user-supplied override paths.
+  private async createSDKFromWheelLayout(
+    sysPrefix: string,
+    pythonMajor: number,
+    pythonMinor: number,
+    kind: SDKKind,
+  ): Promise<SDK | undefined> {
+    const binPath = path.join(sysPrefix, 'bin');
+    const libPath = path.join(
+      sysPrefix,
       'lib',
-      `python${env.version!.major}.${env.version!.minor}`,
+      `python${pythonMajor}.${pythonMinor}`,
       'site-packages',
       'modular',
       'lib',
@@ -367,7 +407,7 @@ export class PythonEnvironmentManager extends DisposableContext {
     const versionResult = await exec(`"${mojoPath}" --version`);
     return new SDK(
       this.logger,
-      SDKKind.Environment,
+      kind,
       versionResult.stdout,
       lspPath,
       mblackPath,
@@ -450,6 +490,86 @@ export class PythonEnvironmentManager extends DisposableContext {
       this.logger.error('Error creating SDK from modular.cfg', e);
       return undefined;
     }
+  }
+
+  /// Attempt to load an SDK from the user-supplied `mojo.sdk.path` setting.
+  /// Updates `overridePathState` as a side effect so callers can distinguish
+  /// "no override set" from "override set but unusable".
+  private async tryGetOverrideSDK(): Promise<SDK | undefined> {
+    const overridePath = config.get<string>('sdk.path', undefined)?.trim();
+    if (!overridePath) {
+      this.overridePathState = 'unset';
+      return undefined;
+    }
+
+    this.logger.info(`Loading SDK from override path: ${overridePath}`);
+
+    if (!(await directoryExists(overridePath))) {
+      this.logger.error(
+        `Override path '${overridePath}' does not exist or is not a directory.`,
+      );
+      this.overridePathState = 'invalid';
+      return undefined;
+    }
+
+    // Try the conda/pixi layout first: <override>/share/max/modular.cfg
+    const homePath = path.join(overridePath, 'share', 'max');
+    if (await fileExists(path.join(homePath, 'modular.cfg'))) {
+      const sdk = await this.createSDKFromHomePath(
+        SDKKind.Custom,
+        homePath,
+        overridePath,
+      );
+      this.overridePathState = sdk ? 'valid' : 'invalid';
+      return sdk;
+    }
+
+    // Fall back to the wheel layout: <override>/lib/python<X>.<Y>/site-packages/modular/...
+    const pythonVersion = await this.detectPythonVersion(overridePath);
+    if (pythonVersion) {
+      const [major, minor] = pythonVersion;
+      const sdk = await this.createSDKFromWheelLayout(
+        overridePath,
+        major,
+        minor,
+        SDKKind.Custom,
+      );
+      this.overridePathState = sdk ? 'valid' : 'invalid';
+      return sdk;
+    }
+
+    this.logger.error(
+      `Override path '${overridePath}' contains neither a 'share/max/modular.cfg' file nor a 'lib/python*' directory.`,
+    );
+    this.overridePathState = 'invalid';
+    return undefined;
+  }
+
+  /// Find a `python<major>.<minor>` directory under `<root>/lib`, returning
+  /// the parsed version. Used to resolve wheel-style install paths whose
+  /// Python version we can't query directly (no Python extension available).
+  private async detectPythonVersion(
+    root: string,
+  ): Promise<[number, number] | undefined> {
+    const libDir = path.join(root, 'lib');
+    let entries: [string, vscode.FileType][];
+    try {
+      entries = await vscode.workspace.fs.readDirectory(
+        vscode.Uri.file(libDir),
+      );
+    } catch {
+      return undefined;
+    }
+    for (const [name, type] of entries) {
+      if (!(type & vscode.FileType.Directory)) {
+        continue;
+      }
+      const match = name.match(/^python(\d+)\.(\d+)$/);
+      if (match) {
+        return [parseInt(match[1], 10), parseInt(match[2], 10)];
+      }
+    }
+    return undefined;
   }
 
   /// Attempt to load a monorepo SDK from the currently open workspace folder.

--- a/extension/statusBar.ts
+++ b/extension/statusBar.ts
@@ -26,16 +26,20 @@ function editorHasMojoFile(): boolean {
   );
 }
 
+export type SDKMissingReason = 'no-python-extension';
+
 export class SDKStatusBar implements vscode.Disposable {
   private statusBarItem: vscode.StatusBarItem;
   private disposables: vscode.Disposable[] = [];
   private visible = false;
   private workspaceHasMojo: boolean | undefined = undefined;
+  private readonly showOutputCommand: string;
   private onShouldRefresh: vscode.EventEmitter<void> =
     new vscode.EventEmitter();
   readonly onRefreshRequested: vscode.Event<void> = this.onShouldRefresh.event;
 
   constructor(showOutputCommand: string) {
+    this.showOutputCommand = showOutputCommand;
     this.statusBarItem = vscode.window.createStatusBarItem(
       'mojo-sdk-status',
       vscode.StatusBarAlignment.Left,
@@ -99,7 +103,7 @@ export class SDKStatusBar implements vscode.Disposable {
     this.statusBarItem.backgroundColor = undefined;
   }
 
-  update(sdk: SDK | undefined) {
+  update(sdk: SDK | undefined, reason?: SDKMissingReason) {
     if (sdk) {
       const version = sdk.version.replace(/^mojo\s*/i, '').trim();
       const kindLabel = SDK_KIND_LABELS[sdk.kind];
@@ -108,12 +112,28 @@ export class SDKStatusBar implements vscode.Disposable {
         `**Mojo SDK** (${kindLabel})\n\nVersion: ${version}\n\nPath: ${sdk.mojoPath}`,
       );
       this.statusBarItem.backgroundColor = undefined;
+      this.statusBarItem.command = this.showOutputCommand;
+    } else if (reason === 'no-python-extension') {
+      this.statusBarItem.text = '$(warning) Mojo: Install Python extension';
+      this.statusBarItem.tooltip = new vscode.MarkdownString(
+        'The Python extension (`ms-python.python`) is required to discover ' +
+          'Mojo SDKs in pixi or wheel environments.\n\nClick to open it in the marketplace.',
+      );
+      this.statusBarItem.backgroundColor = new vscode.ThemeColor(
+        'statusBarItem.warningBackground',
+      );
+      this.statusBarItem.command = {
+        command: 'extension.open',
+        arguments: ['ms-python.python'],
+        title: 'Open Python extension in marketplace',
+      };
     } else {
       this.statusBarItem.text = '$(warning) Mojo: No SDK';
       this.statusBarItem.tooltip = 'No Mojo SDK detected. Click to view logs.';
       this.statusBarItem.backgroundColor = new vscode.ThemeColor(
         'statusBarItem.warningBackground',
       );
+      this.statusBarItem.command = this.showOutputCommand;
     }
   }
 

--- a/extension/statusBar.ts
+++ b/extension/statusBar.ts
@@ -26,7 +26,7 @@ function editorHasMojoFile(): boolean {
   );
 }
 
-export type SDKMissingReason = 'no-python-extension';
+export type SDKMissingReason = 'no-python-extension' | 'invalid-sdk-override';
 
 export class SDKStatusBar implements vscode.Disposable {
   private statusBarItem: vscode.StatusBarItem;
@@ -126,6 +126,21 @@ export class SDKStatusBar implements vscode.Disposable {
         command: 'extension.open',
         arguments: ['ms-python.python'],
         title: 'Open Python extension in marketplace',
+      };
+    } else if (reason === 'invalid-sdk-override') {
+      this.statusBarItem.text = '$(error) Mojo: Invalid SDK override path';
+      this.statusBarItem.tooltip = new vscode.MarkdownString(
+        'The `mojo.sdk.path` setting is set but does not point to a valid ' +
+          'Mojo SDK. The extension will not fall back to other detection ' +
+          'while this override is set.\n\nClick to open the setting.',
+      );
+      this.statusBarItem.backgroundColor = new vscode.ThemeColor(
+        'statusBarItem.errorBackground',
+      );
+      this.statusBarItem.command = {
+        command: 'workbench.action.openSettings',
+        arguments: ['mojo.sdk.path'],
+        title: 'Open Mojo SDK path setting',
       };
     } else {
       this.statusBarItem.text = '$(warning) Mojo: No SDK';

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "onUri",
     "onStartupFinished"
   ],
-  "extensionDependencies": [
-    "ms-python.python"
-  ],
   "main": "./out/extension.js",
   "scripts": {
     "vscode:prepublish": "npm run typecheck && npm run bundle",

--- a/package.json
+++ b/package.json
@@ -172,6 +172,12 @@
           "type": "boolean",
           "default": false,
           "description": "Whether to focus on the terminal used by the `Mojo: Run Mojo File` command or on the editor after launch."
+        },
+        "mojo.sdk.path": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Absolute path to a Mojo SDK environment root. When set, this overrides all auto-detection (including the monorepo `.derived/` SDK and any environment selected via the Python extension) and will not fall back to auto-detection if invalid.\n\n**For pixi or conda installs**, point to the environment root that contains `share/max/modular.cfg` — for example, `/path/to/workspace/.pixi/envs/default`.\n\n**For wheel installs**, point to the environment root that contains `bin/mojo` and `lib/python*/site-packages/modular/` — for example, `/path/to/.venv`."
         }
       }
     },


### PR DESCRIPTION
Remove ms-python.python from extensionDependencies so the extension can install in VS Code derivatives (e.g. Cursor) whose marketplaces cannot resolve the dependency at install time. Behavior when the Python extension is installed is unchanged.

When the Python extension is not installed:

<img width="253" height="45" alt="mojo-install-python" src="https://github.com/user-attachments/assets/8caefe2e-4374-44d9-8931-d1e0ae1a7fff" />

- Monorepo SDK detection (`.derived/`) runs first and is unaffected, so monorepo workflows succeed without the Python extension.
- The Mojo SDK status bar shows "Install Python extension" with a click action that opens the extension in the marketplace, replacing the previous modal error dialog.
- The extension reactively picks up ms-python.python being installed mid-session (via vscode.extensions.onDidChange), so users don't need to reload the window after installing from the prompt.

`mojo.sdk.path` override:

To address the concern that users who uninstall the Python extension (or who cannot install it at all) lose SDK discovery silently, this PR adds a `mojo.sdk.path` setting that lets users point the extension at an SDK installation directly. When set, this overrides every other detection source (including the monorepo path) and does not fall back if invalid — an explicit error is surfaced in the status bar instead. The setting accepts both pixi/conda env roots and wheel-style env roots; see the README for layout details and examples.

Other changes:

- The pixi test config in .vscode-test.mjs explicitly installs ms-python.python, since it's no longer pulled in transitively via extensionDependencies.
- README updated with the new SDK resolution priority order and a section on the override setting.
- Replaces the dead `SDK.additionalSDKs` configWatcher entry with `sdk.path` — the old key was watched for changes but never declared in the manifest or read anywhere.

Test Plan:

- [x] Remove python extension, restart extensions, open modular dev monorepo - ensure that the SDK is still reported in the status bar item
- [x] Remove python extension, restart extensions, open a project folder including a .pixi environment with SDK and also .mojo files - ensure that the status bar item reports that the python extension should be installed
- [x] Click the status bar item when it reports that the python extension should be installed - ensure it takes you to the relevant extension page
- [x] Install the python extension - ensure that the status bar item reloads automatically and the SDK is detected (use the command palette to pick Python Interpreter if necessary)