### PR TITLE
fix: allow mojo.lsp.includeDirs to be set at workspace level

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
           ]
         },
         "mojo.lsp.includeDirs": {
-          "scope": "machine",
+          "scope": "window",
           "type": "array",
           "description": "List of directories to append to the search path list used to resolve imported modules in a document.",
           "items": {


### PR DESCRIPTION
## Summary

Fixes MOCO-3891 / https://github.com/modular/modular/issues/6482

The `mojo.lsp.includeDirs` setting was declared with `"scope": "machine"`, which restricts it to User-level settings only. This means all projects on a machine share a single global list of include paths — there is no way to configure per-workspace paths in `.vscode/settings.json` or a `.code-workspace` file.

This change updates the scope to `"window"`, which allows the setting to be configured at any level (User, Workspace, or Folder). Users with multi-directory project layouts (e.g. `src/` + `test/`) can now add workspace-specific include paths so the Mojo LSP correctly resolves cross-directory imports without polluting their global settings.

## Change

- `package.json`: `mojo.lsp.includeDirs` scope `"machine"` → `"window"`

## Test plan

- [x] Open a project with a `src/` and `test/` directory structure
- [x] Add `"mojo.lsp.includeDirs": ["${workspaceFolder}/src"]` to `.vscode/settings.json`
- [x] Verify the setting is accepted (no "unsupported property" warning)
- [ ] Verify the Mojo LSP resolves imports from `src/` in files under `test/`
- [ ] Verify User-level settings still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)