### PR TITLE
fix: add buildArgs to mojo-lldb debug configuration schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -501,6 +501,14 @@
                 "description": "Program arguments.",
                 "default": []
               },
+              "buildArgs": {
+                "type": [
+                  "array",
+                  "string"
+                ],
+                "description": "Build arguments when using `mojoFile` instead of `program`.",
+                "default": []
+              },
               "cwd": {
                 "type": "string",
                 "description": "Program working directory.",


### PR DESCRIPTION
## Summary

Fixes MOTO-1578 / https://github.com/modular/modular/issues/6472

The `buildArgs` property is already supported by the `mojo-lldb` debug adapter — it allows passing compiler flags (e.g. `-I ./src`) when launching a Mojo file via `mojoFile` in `launch.json`. However, `buildArgs` was not declared in `package.json`'s `configurationAttributes` for the `mojo-lldb` type, so VSCode flagged it as an unsupported property with a yellow squiggle, even though it worked at runtime.

The `mojo-cuda-gdb` adapter already had `buildArgs` correctly declared. This change brings `mojo-lldb` in line with it.

A common use case is projects with separate `src/` and `test/` directories, where the debugger needs the `-I src` flag to resolve cross-directory imports:

```json
{
  "type": "mojo-lldb",
  "request": "launch",
  "name": "Debug test",
  "mojoFile": "${file}",
  "buildArgs": ["-I", "${workspaceFolder}/src"]
}
```

## Change

- `package.json`: add `buildArgs` to `mojo-lldb` `configurationAttributes.launch.properties`

## Test plan

- [x] Add `"buildArgs": ["-I", "./src"]` to a `mojo-lldb` launch configuration in `launch.json`
- [x] Verify the yellow "Unsupported property" squiggle is gone
- [ ] Verify autocomplete suggests `buildArgs` when editing `launch.json`
- [ ] Verify a debug session with `buildArgs` still launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)