### PR TITLE
Clean up stale lsp-proxy CI config, add pre-commit ecosystem

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -11,10 +11,8 @@ runs:
     - name: Cache Node packages
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
       with:
-        key: npm-${{ hashFiles('package-lock.json', 'lsp-proxy/package-lock.json') }}
-        path: |
-          node_modules
-          lsp-proxy/node_modules
+        key: npm-${{ hashFiles('package-lock.json') }}
+        path: node_modules
 
     - name: Install dependencies
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,20 +18,18 @@ updates:
       prefix: "npm"
       include: "scope"
 
-  # Enable version updates for npm (lsp-proxy subdirectory)
-  - package-ecosystem: "npm"
-    directory: "/lsp-proxy"
+  # Enable version updates for pre-commit hooks
+  - package-ecosystem: "pre-commit"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-    versioning-strategy: lockfile-only
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "npm"
-      - "lsp-proxy"
+      - "pre-commit"
     commit-message:
-      prefix: "npm"
+      prefix: "pre-commit"
       include: "scope"
 
   # Enable version updates for GitHub Actions


### PR DESCRIPTION
Removes the residual references to `/lsp-proxy/` left behind after PR #155 deleted the directory: the dependabot.yml entry that watched a path that no longer exists, and the cache key/path in the composite setup action that hashed and cached files that no longer exist.

While editing dependabot.yml, also adds a `pre-commit` ecosystem entry so the hooks pinned in `.pre-commit-config.yaml` get tracked for updates — currently `pre-commit/pre-commit-hooks@v5.0.0` is the only externally-pinned hook, but the entry catches future ones.