### PR TITLE
Enable OpenSSF Scorecard Branch-Protection check

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,11 +43,11 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
-          # - you want to enable the Branch-Protection check on a *public* repository, or
-          # - you are installing Scorecard on a *private* repository
-          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
-          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          # Fine-grained PAT scoped to this repo with `Administration: Read`
+          # only. Needed so the Branch-Protection check can query the
+          # protection rules on `main`; without this it falls back to the
+          # auto-generated GITHUB_TOKEN, which doesn't have admin:read.
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
 
           # Public repositories:
           #   - Publish results to OpenSSF REST API for easy access by consumers


### PR DESCRIPTION
The Scorecard workflow's Branch-Protection check needs `administration: read` access to query the branch protection rules on `main`, which the auto-generated GITHUB_TOKEN doesn't have. The check has been erroring with "Resource not accessible by integration" and counting as N/A.

Pass a fine-grained PAT (scoped to this repo, `Administration: Read` only) via the action's existing `repo_token` parameter so the check can grade the protection rules properly.