### PR TITLE
docs:add configuration snippet for format on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,15 @@ From the command palette run `Format Document` or tick the setting
 
 ![format](https://github.com/modular/mojo/assets/77730378/4e0e22c4-0216-41d7-b5a5-7f48a018fd81)
 
+To format your code automatically whenever you save a Mojo file, add the following configuration block to your user `settings.json` or your project's `.vscode/settings.json`:
+
+```json
+"[mojo]": {
+    "editor.defaultFormatter": "modular-mojotools.vscode-mojo",
+    "editor.formatOnSave": true
+}
+```
+
 ## Restarting Mojo extension
 
 The extension may crash and produce incorrect results periodically, to fix this


### PR DESCRIPTION
### Description
Clarified the "Code formatting" section to provide an explicit VS Code configuration block for enabling `formatOnSave`. 

### Motivation
The current documentation tells users to "tick the setting Format on Save", but this fails if developers have multiple language formatters active (such as Prettier, Black, or Ruff). VS Code requires an explicit `editor.defaultFormatter` assignment inside `settings.json` to safely delegate formatting for `.mojo` files.

Adding this explicit JSON block saves developers from having to search for the extension's internal identifier (`modular-mojotools.vscode-mojo`).

### Checklist
- [x] I have kept the changes small and focused.
- [x] No code logic was altered; this is a pure documentation enhancement.