### PR TITLE
Fixes Mojo alias highlighting in VS Code by post-processing semantic tokens returned from LSP server

### DIFF
--- a/extension/lsp/lsp.ts
+++ b/extension/lsp/lsp.ts
@@ -23,6 +23,15 @@ import { LSPRecorder } from './recorder';
 import { Optional } from '../types';
 import { PythonEnvironmentManager, SDK } from '../pyenv';
 import { SDKStatusBar } from '../statusBar';
+import {
+  correctAliasSemanticTokens,
+  SemanticTokenTypeIndexes,
+} from './semanticTokens';
+
+type ProtocolSemanticTokens = {
+  data?: number[];
+  resultId?: string;
+} | null;
 
 /// Wraps the language client's default error handler so we can observe when
 /// the library's crash cap fires (i.e. `closed()` returns `DoNotRestart`).
@@ -334,6 +343,8 @@ export class MojoLSPManager extends DisposableContext {
     });
 
     // Configure the client options.
+    let languageClient: vscodelc.LanguageClient;
+    let tokenTypeIndexes: SemanticTokenTypeIndexes | undefined;
     const clientOptions: vscodelc.LanguageClientOptions = {
       errorHandler: crashCapObserver,
       // All Mojo documents are served by a single language server; multiple
@@ -375,6 +386,57 @@ export class MojoLSPManager extends DisposableContext {
           return next(method, param);
         }
       },
+      async provideDocumentSemanticTokens(document, token, next) {
+        const semanticTokens = await next(document, token);
+        return correctAliasSemanticTokens(
+          document,
+          semanticTokens ?? undefined,
+          tokenTypeIndexes,
+        );
+      },
+      async provideDocumentSemanticTokensEdits(
+        document,
+        previousResultId,
+        token,
+        next,
+      ) {
+        const editResult = await next(document, previousResultId, token);
+        if (editResult instanceof vscode.SemanticTokens) {
+          return correctAliasSemanticTokens(
+            document,
+            editResult,
+            tokenTypeIndexes,
+          );
+        }
+        if (token.isCancellationRequested) {
+          return undefined;
+        }
+
+        // SemanticTokensEdits are relative to VS Code's previous token array,
+        // so request a full snapshot when the server returns edits. That keeps
+        // the alias correction context-aware instead of trying to patch deltas.
+        const result = await languageClient.sendRequest<ProtocolSemanticTokens>(
+          'textDocument/semanticTokens/full',
+          {
+            textDocument:
+              languageClient.code2ProtocolConverter.asTextDocumentIdentifier(
+                document,
+              ),
+          },
+          token,
+        );
+        if (result === null || token.isCancellationRequested) {
+          return undefined;
+        }
+        return correctAliasSemanticTokens(
+          document,
+          new vscode.SemanticTokens(
+            new Uint32Array(result.data ?? []),
+            result.resultId,
+          ),
+          tokenTypeIndexes,
+        );
+      },
       async handleDiagnostics(uri, diagnostics, next) {
         if (
           config.get<boolean>(
@@ -408,12 +470,24 @@ export class MojoLSPManager extends DisposableContext {
     };
 
     // Create the language client and start the client.
-    const languageClient = new vscodelc.LanguageClient(
+    languageClient = new vscodelc.LanguageClient(
       'mojo-lsp',
       'Mojo Language Client',
       serverOptions,
       clientOptions,
     );
+    languageClient.onDidChangeState((event) => {
+      if (event.newState !== vscodelc.State.Running) {
+        return;
+      }
+      const tokenTypes =
+        languageClient.initializeResult?.capabilities.semanticTokensProvider
+          ?.legend.tokenTypes;
+      const variable = tokenTypes?.indexOf('variable') ?? -1;
+      const type = tokenTypes?.indexOf('type') ?? -1;
+      tokenTypeIndexes =
+        variable >= 0 && type >= 0 ? { variable, type } : undefined;
+    });
     crashCapObserver.setInner(languageClient.createDefaultErrorHandler());
 
     this.logger.lsp.info(

--- a/extension/lsp/semanticTokens.test.default.ts
+++ b/extension/lsp/semanticTokens.test.default.ts
@@ -1,0 +1,119 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2025, Modular Inc. All rights reserved.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions:
+// https://llvm.org/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { correctAliasSemanticTokens } from './semanticTokens';
+
+const variableTokenType = 0;
+const typeTokenType = 8;
+
+function createDocument(lines: string[]) {
+  return {
+    lineAt(line: number) {
+      return { text: lines[line] } as vscode.TextLine;
+    },
+  } as unknown as vscode.TextDocument;
+}
+
+type TestToken = {
+  line: number;
+  character: number;
+  length: number;
+  tokenType?: number;
+};
+
+function encodeTokens(tokens: TestToken[]) {
+  const data: number[] = [];
+  let previousLine = 0;
+  let previousCharacter = 0;
+
+  for (const current of tokens) {
+    const deltaLine = current.line - previousLine;
+    data.push(
+      deltaLine,
+      deltaLine === 0
+        ? current.character - previousCharacter
+        : current.character,
+      current.length,
+      current.tokenType ?? variableTokenType,
+      0,
+    );
+    previousLine = current.line;
+    previousCharacter = current.character;
+  }
+
+  return new Uint32Array(data);
+}
+
+suite('Semantic token correction', () => {
+  test('reclassifies aliases only in type positions', () => {
+    const lines = [
+      'var custom: MyInt',
+      'def write_to(self, mut writer: Some[Writer]):',
+      'def f() -> Int: return value',
+      'return MyList[Int]()',
+    ];
+    const semanticTokens = new vscode.SemanticTokens(
+      encodeTokens([
+        {
+          line: 0,
+          character: lines[0].indexOf('MyInt'),
+          length: 'MyInt'.length,
+        },
+        {
+          line: 1,
+          character: lines[1].indexOf('writer'),
+          length: 'writer'.length,
+        },
+        { line: 1, character: lines[1].indexOf('Some'), length: 'Some'.length },
+        {
+          line: 1,
+          character: lines[1].indexOf('Writer'),
+          length: 'Writer'.length,
+        },
+        { line: 2, character: lines[2].indexOf('Int'), length: 'Int'.length },
+        {
+          line: 2,
+          character: lines[2].indexOf('value'),
+          length: 'value'.length,
+        },
+        {
+          line: 3,
+          character: lines[3].indexOf('MyList'),
+          length: 'MyList'.length,
+        },
+      ]),
+    );
+
+    const corrected = correctAliasSemanticTokens(
+      createDocument(lines),
+      semanticTokens,
+      { variable: variableTokenType, type: typeTokenType },
+    );
+
+    assert.ok(corrected);
+    const tokenTypes = Array.from(corrected.data).filter((_, index) => {
+      return index % 5 === 3;
+    });
+    assert.deepStrictEqual(tokenTypes, [
+      typeTokenType,
+      variableTokenType,
+      typeTokenType,
+      typeTokenType,
+      typeTokenType,
+      variableTokenType,
+      variableTokenType,
+    ]);
+  });
+});

--- a/extension/lsp/semanticTokens.ts
+++ b/extension/lsp/semanticTokens.ts
@@ -1,0 +1,199 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2025, Modular Inc. All rights reserved.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions:
+// https://llvm.org/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import * as vscode from 'vscode';
+
+const SEMANTIC_TOKEN_ENTRY_SIZE = 5;
+
+export type SemanticTokenTypeIndexes = {
+  variable: number;
+  type: number;
+};
+
+type SemanticTokenSpan = {
+  line: number;
+  character: number;
+  length: number;
+  tokenType: number;
+  tokenModifiers: number;
+};
+
+function decodeSemanticTokens(data: Uint32Array): SemanticTokenSpan[] {
+  const tokens: SemanticTokenSpan[] = [];
+  let line = 0;
+  let character = 0;
+
+  for (let i = 0; i < data.length; i += SEMANTIC_TOKEN_ENTRY_SIZE) {
+    line += data[i];
+    character = data[i] === 0 ? character + data[i + 1] : data[i + 1];
+    tokens.push({
+      line,
+      character,
+      length: data[i + 2],
+      tokenType: data[i + 3],
+      tokenModifiers: data[i + 4],
+    });
+  }
+
+  return tokens;
+}
+
+function encodeSemanticTokens(tokens: SemanticTokenSpan[]): Uint32Array {
+  const data = new Uint32Array(tokens.length * SEMANTIC_TOKEN_ENTRY_SIZE);
+  let previousLine = 0;
+  let previousCharacter = 0;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    const offset = i * SEMANTIC_TOKEN_ENTRY_SIZE;
+    const deltaLine = token.line - previousLine;
+    data[offset] = deltaLine;
+    data[offset + 1] =
+      deltaLine === 0 ? token.character - previousCharacter : token.character;
+    data[offset + 2] = token.length;
+    data[offset + 3] = token.tokenType;
+    data[offset + 4] = token.tokenModifiers;
+    previousLine = token.line;
+    previousCharacter = token.character;
+  }
+
+  return data;
+}
+
+function findTypeContextStart(line: string, character: number): number {
+  const prefix = line.slice(0, character);
+  let bracketDepth = 0;
+  let parenDepth = 0;
+  let inString: string | undefined;
+  let contextStart = -1;
+
+  for (let i = 0; i < prefix.length; i++) {
+    const current = prefix[i];
+    const previous = prefix[i - 1];
+
+    if (inString !== undefined) {
+      if (current === inString && previous !== '\\') {
+        inString = undefined;
+      }
+      continue;
+    }
+
+    if (current === '"' || current === "'") {
+      inString = current;
+      continue;
+    }
+
+    if (current === '[') {
+      bracketDepth++;
+    } else if (current === ']') {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+    } else if (current === '(') {
+      parenDepth++;
+    } else if (current === ')') {
+      parenDepth = Math.max(0, parenDepth - 1);
+      if (bracketDepth === 0) {
+        contextStart = -1;
+      }
+    }
+
+    if (bracketDepth !== 0) {
+      continue;
+    }
+
+    if (current === ':' && bracketDepth === 0) {
+      contextStart = startsTypeAnnotation(prefix.slice(0, i), parenDepth)
+        ? i + 1
+        : -1;
+      continue;
+    }
+
+    if (current === '-' && prefix[i + 1] === '>') {
+      contextStart = i + 2;
+      i++;
+      continue;
+    }
+
+    if (current === ',' || current === '=' || current === '#') {
+      contextStart = -1;
+    }
+  }
+
+  return contextStart;
+}
+
+function startsTypeAnnotation(left: string, parenDepth: number): boolean {
+  if (/\b(?:var|let)\s+[A-Za-z_]\w*\s*$/.test(left)) {
+    return true;
+  }
+
+  return (
+    parenDepth > 0 &&
+    /(?:^|[,\(])\s*(?:(?:var|read|mut|out|ref)\s+)?[A-Za-z_]\w*\s*$/.test(left)
+  );
+}
+
+function isInStructInheritance(line: string, character: number): boolean {
+  const prefix = line.slice(0, character);
+  return /\b(?:struct|trait|class)\s+\w+\s*\([^)]*$/.test(prefix);
+}
+
+function isTokenInTypeContext(
+  document: vscode.TextDocument,
+  token: SemanticTokenSpan,
+): boolean {
+  const line = document.lineAt(token.line).text;
+
+  if (isInStructInheritance(line, token.character)) {
+    return true;
+  }
+
+  const contextStart = findTypeContextStart(line, token.character);
+  if (contextStart < 0) {
+    return false;
+  }
+
+  const between = line.slice(contextStart, token.character);
+  return !/[=#]/.test(between);
+}
+
+export function correctAliasSemanticTokens(
+  document: vscode.TextDocument,
+  semanticTokens: vscode.SemanticTokens | undefined,
+  tokenTypeIndexes: SemanticTokenTypeIndexes | undefined,
+): vscode.SemanticTokens | undefined {
+  if (semanticTokens === undefined || tokenTypeIndexes === undefined) {
+    return semanticTokens;
+  }
+
+  const tokens = decodeSemanticTokens(semanticTokens.data);
+  let changed = false;
+
+  for (const token of tokens) {
+    if (
+      token.tokenType === tokenTypeIndexes.variable &&
+      isTokenInTypeContext(document, token)
+    ) {
+      token.tokenType = tokenTypeIndexes.type;
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    return semanticTokens;
+  }
+
+  return new vscode.SemanticTokens(
+    encodeSemanticTokens(tokens),
+    semanticTokens.resultId,
+  );
+}


### PR DESCRIPTION
The LSP currently resolves aliases like `Some` for hover, but emits them as `variable` semantic tokens. This patch reclassifies `variable` tokens as `type` only when they appear in syntactic type positions, such as:

- parameter annotations: `writer: Some[Writer]`
- variable annotations: `var x: MyAlias`
- return annotations: `-> MyAlias`
- trait/inheritance lists: `struct Foo(Copyable, Writable)`

A minimal regression test was added for the semantic-token correction behavior.

Note that, this is an extension-side workaround. The more correct long-term fix should likely live in `mojo-lsp-server`, which has the semantic information needed to classify aliases directly as type-like semantic tokens instead of `variable`.