### PR TITLE
Add setting for turning on docstring checking

### DIFF
--- a/extension/lsp/lsp.ts
+++ b/extension/lsp/lsp.ts
@@ -312,6 +312,16 @@ export class MojoLSPManager extends DisposableContext {
       serverArgs.push('-I', includeDir);
     }
 
+    if (
+      config.get<boolean>(
+        'lsp.checkDocstrings',
+        /*workspaceFolder=*/ undefined,
+        false,
+      )
+    ) {
+      serverArgs.push('-check-docstrings');
+    }
+
     if (this.attachDebugger) {
       serverArgs.push('--attach-debugger-on-startup');
     }

--- a/extension/lsp/lsp.ts
+++ b/extension/lsp/lsp.ts
@@ -385,36 +385,6 @@ export class MojoLSPManager extends DisposableContext {
           return next(method, param);
         }
       },
-      async handleDiagnostics(uri, diagnostics, next) {
-        if (
-          config.get<boolean>(
-            'lsp.suppress.diagnostics.in.docstring',
-            /*workspaceFolder=*/ undefined,
-            false,
-          )
-        ) {
-          const document = await vscode.workspace.openTextDocument(uri);
-          const foldingRanges = await vscode.commands.executeCommand<
-            vscode.FoldingRange[]
-          >('vscode.executeFoldingRangeProvider', uri);
-          const docstringRanges = foldingRanges.filter((r) => {
-            return document.lineAt(r.start).text.trimStart().startsWith('"""');
-          });
-          diagnostics = diagnostics.filter((d) => {
-            for (let index = 0; index < docstringRanges.length; index++) {
-              const range = docstringRanges[index];
-              if (
-                d.range.start.line > range.start &&
-                d.range.end.line < range.end
-              ) {
-                return false;
-              }
-            }
-            return true;
-          });
-        }
-        next(uri, diagnostics);
-      },
     };
 
     // Create the language client and start the client.

--- a/package.json
+++ b/package.json
@@ -157,12 +157,6 @@
           ],
           "description": "Parse and type-check code blocks inside doc strings. When disabled (the default), the language server validates docstring structure but ignores errors inside docstring code-block examples."
         },
-        "mojo.lsp.suppress.diagnostics.in.docstring": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": false,
-          "description": "Suppress warnings and errors in docstring."
-        },
         "mojo.formatting.args": {
           "scope": "resource",
           "type": "array",

--- a/package.json
+++ b/package.json
@@ -148,6 +148,15 @@
             "type": "string"
           }
         },
+        "mojo.lsp.checkDocstrings": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "tags": [
+            "experimental"
+          ],
+          "description": "Parse and type-check code blocks inside doc strings. When disabled (the default), the language server validates docstring structure but ignores errors inside docstring code-block examples."
+        },
         "mojo.lsp.suppress.diagnostics.in.docstring": {
           "scope": "resource",
           "type": "boolean",


### PR DESCRIPTION
The latest LSP server no longer checks code-blocks in doc-strings by default. It instead ships with a new `-check-docstrings` flag that turns on this experimental feature. Add a setting in the extension so users can toggle this flag on.