### PR TITLE
Add breakpoint-hit verification to the debug test body

### DIFF
--- a/extension/debug/debugTestBody.ts
+++ b/extension/debug/debugTestBody.ts
@@ -91,11 +91,8 @@ suite('debug', function () {
     const workspaceFolder = vscode.workspace.workspaceFolders![0];
     const mojoFile = path.join(workspaceFolder.uri.fsPath, 'main.mojo');
 
-    // main.mojo is:
-    //   def main():
-    //       print("hello, world")
-    // The print statement is line 2 (0-indexed as 1); line 1 is the
-    // `def` declaration which LLDB won't stop on.
+    // Set the breakpoint on line 2 (0-indexed as 1) — the print statement.
+    // Line 1 is `def main():` which LLDB won't stop on.
     const breakpoint = new vscode.SourceBreakpoint(
       new vscode.Location(vscode.Uri.file(mojoFile), new vscode.Position(1, 0)),
     );

--- a/extension/debug/debugTestBody.ts
+++ b/extension/debug/debugTestBody.ts
@@ -84,4 +84,75 @@ suite('debug', function () {
     }
     assert.ok(cleaned, `Temp dir ${tempDir} should have been cleaned up`);
   });
+
+  test('debug session stops at a breakpoint and continues', async function () {
+    this.timeout(60_000);
+
+    const workspaceFolder = vscode.workspace.workspaceFolders![0];
+    const mojoFile = path.join(workspaceFolder.uri.fsPath, 'main.mojo');
+
+    // main.mojo is:
+    //   def main():
+    //       print("hello, world")
+    // The print statement is line 2 (0-indexed as 1); line 1 is the
+    // `def` declaration which LLDB won't stop on.
+    const breakpoint = new vscode.SourceBreakpoint(
+      new vscode.Location(vscode.Uri.file(mojoFile), new vscode.Position(1, 0)),
+    );
+    vscode.debug.addBreakpoints([breakpoint]);
+
+    // Observe DAP traffic to catch the "stopped at breakpoint" event and
+    // send a continue in response, so the program can exit and the test
+    // can finish. Registered before startDebugging so the factory fires
+    // for the session we're about to launch.
+    let stoppedAtBreakpoint = false;
+    const trackerReg = vscode.debug.registerDebugAdapterTrackerFactory(
+      'mojo-lldb',
+      {
+        createDebugAdapterTracker(session) {
+          return {
+            onDidSendMessage(message) {
+              if (
+                message.type === 'event' &&
+                message.event === 'stopped' &&
+                message.body?.reason === 'breakpoint'
+              ) {
+                stoppedAtBreakpoint = true;
+                void session.customRequest('continue', {
+                  threadId: message.body.threadId,
+                });
+              }
+            },
+          };
+        },
+      },
+    );
+
+    try {
+      const termPromise = new Promise<void>((resolve) => {
+        const sub = vscode.debug.onDidTerminateDebugSession(() => {
+          sub.dispose();
+          resolve();
+        });
+      });
+
+      const started = await vscode.debug.startDebugging(workspaceFolder, {
+        type: 'mojo-lldb',
+        name: 'Debug main.mojo with breakpoint',
+        request: 'launch',
+        mojoFile,
+      });
+      assert.ok(started, 'startDebugging should have returned true');
+
+      await termPromise;
+
+      assert.ok(
+        stoppedAtBreakpoint,
+        'Session should have stopped at the breakpoint on line 2',
+      );
+    } finally {
+      trackerReg.dispose();
+      vscode.debug.removeBreakpoints([breakpoint]);
+    }
+  });
 });


### PR DESCRIPTION
Extend debugTestBody with a second test that:
- Sets a SourceBreakpoint at main.mojo line 2 (the print statement).
- Registers a DebugAdapterTrackerFactory to watch DAP traffic.
- When the tracker sees a `stopped` event with reason "breakpoint", flips a flag and sends a `continue` request so the program can finish naturally.
- Waits for termination and asserts the flag was set.

try/finally around the session ensures the breakpoint and tracker are cleaned up even if assertions fail, avoiding leftover state between tests.

Runs under both pixi and uv labels on both OSes via the existing shared-body wrappers.