### PR TITLE
Add unit tests for CrashCapObserver

### DIFF
--- a/extension/lsp/crashCapObserver.test.default.ts
+++ b/extension/lsp/crashCapObserver.test.default.ts
@@ -15,18 +15,13 @@ import * as assert from 'assert';
 import * as vscodelc from 'vscode-languageclient/node';
 import { CrashCapObserver } from './crashCapObserver';
 
-/// Build a stub ErrorHandler that always returns the given actions.
-/// error() returns Continue for count <= 3 and Shutdown otherwise, mirroring
-/// the default handler's shape closely enough for our purposes.
+/// Build a stub ErrorHandler whose closed() returns the given action.
+/// error() is a no-op returning Continue since these tests focus on the
+/// crash-cap logic in closed().
 function stubHandler(closeAction: vscodelc.CloseAction): vscodelc.ErrorHandler {
   return {
-    async error(_e, _m, count) {
-      return {
-        action:
-          count && count > 3
-            ? vscodelc.ErrorAction.Shutdown
-            : vscodelc.ErrorAction.Continue,
-      };
+    async error() {
+      return { action: vscodelc.ErrorAction.Continue };
     },
     async closed() {
       return { action: closeAction };

--- a/extension/lsp/crashCapObserver.test.default.ts
+++ b/extension/lsp/crashCapObserver.test.default.ts
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2026, Modular Inc. All rights reserved.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions:
+// https://llvm.org/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import * as assert from 'assert';
+import * as vscodelc from 'vscode-languageclient/node';
+import { CrashCapObserver } from './crashCapObserver';
+
+/// Build a stub ErrorHandler that always returns the given actions.
+/// error() returns Continue for count <= 3 and Shutdown otherwise, mirroring
+/// the default handler's shape closely enough for our purposes.
+function stubHandler(closeAction: vscodelc.CloseAction): vscodelc.ErrorHandler {
+  return {
+    async error(_e, _m, count) {
+      return {
+        action:
+          count && count > 3
+            ? vscodelc.ErrorAction.Shutdown
+            : vscodelc.ErrorAction.Continue,
+      };
+    },
+    async closed() {
+      return { action: closeAction };
+    },
+  };
+}
+
+suite('CrashCapObserver', function () {
+  test('fires onCappedOut when inner.closed() returns DoNotRestart', async function () {
+    let firedCount = 0;
+    const observer = new CrashCapObserver(() => firedCount++);
+    observer.setInner(stubHandler(vscodelc.CloseAction.DoNotRestart));
+
+    const result = await observer.closed();
+
+    assert.strictEqual(firedCount, 1);
+    assert.strictEqual(result.action, vscodelc.CloseAction.DoNotRestart);
+  });
+
+  test('does not fire onCappedOut when inner.closed() returns Restart', async function () {
+    let firedCount = 0;
+    const observer = new CrashCapObserver(() => firedCount++);
+    observer.setInner(stubHandler(vscodelc.CloseAction.Restart));
+
+    const result = await observer.closed();
+
+    assert.strictEqual(firedCount, 0);
+    assert.strictEqual(result.action, vscodelc.CloseAction.Restart);
+  });
+
+  test('fires onCappedOut once per DoNotRestart response, across multiple calls', async function () {
+    let firedCount = 0;
+    const observer = new CrashCapObserver(() => firedCount++);
+    // Inner behaves like the real cap: Restart the first few times, then
+    // DoNotRestart on the Nth close.
+    let closeCount = 0;
+    observer.setInner({
+      async error() {
+        return { action: vscodelc.ErrorAction.Continue };
+      },
+      async closed() {
+        closeCount++;
+        return {
+          action:
+            closeCount <= 4
+              ? vscodelc.CloseAction.Restart
+              : vscodelc.CloseAction.DoNotRestart,
+        };
+      },
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await observer.closed();
+    }
+
+    // 4 Restarts + 1 DoNotRestart => callback fires exactly once.
+    assert.strictEqual(firedCount, 1);
+  });
+
+  test('passes through error() to inner and returns its result', async function () {
+    const received: Array<{ error: Error; count: number | undefined }> = [];
+    const observer = new CrashCapObserver(() => {
+      /* not expected to fire from error() */
+    });
+    observer.setInner({
+      async error(e, _m, count) {
+        received.push({ error: e, count });
+        return { action: vscodelc.ErrorAction.Shutdown };
+      },
+      async closed() {
+        return { action: vscodelc.CloseAction.Restart };
+      },
+    });
+
+    const err = new Error('boom');
+    const result = await observer.error(err, undefined, 7);
+
+    assert.strictEqual(received.length, 1);
+    assert.strictEqual(received[0].error, err);
+    assert.strictEqual(received[0].count, 7);
+    assert.strictEqual(result.action, vscodelc.ErrorAction.Shutdown);
+  });
+
+  test('safe defaults when setInner has not been called', async function () {
+    // If closed() fires before setInner has run (shouldn't happen in
+    // practice, but the safety net matters), default to DoNotRestart so
+    // the user still sees the crash-cap UI rather than an infinite
+    // restart loop.
+    let firedCount = 0;
+    const observer = new CrashCapObserver(() => firedCount++);
+
+    const result = await observer.closed();
+
+    assert.strictEqual(result.action, vscodelc.CloseAction.DoNotRestart);
+    assert.strictEqual(firedCount, 1);
+  });
+
+  test('error() defaults to Continue when setInner has not been called', async function () {
+    const observer = new CrashCapObserver(() => {
+      /* not expected */
+    });
+
+    const result = await observer.error(new Error('boom'), undefined, 1);
+
+    assert.strictEqual(result.action, vscodelc.ErrorAction.Continue);
+  });
+});

--- a/extension/lsp/crashCapObserver.ts
+++ b/extension/lsp/crashCapObserver.ts
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2026, Modular Inc. All rights reserved.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions:
+// https://llvm.org/LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import * as vscodelc from 'vscode-languageclient/node';
+import { Message } from 'vscode-languageserver-protocol';
+
+/// Wraps the language client's default error handler so we can observe when
+/// the library's crash cap fires (i.e. `closed()` returns `DoNotRestart`).
+/// The library's cap policy is a private decision otherwise — no event
+/// surfaces it — so intercepting the handler is the only way to distinguish
+/// "stopped after crash cap" from "stopped for another reason" in the UI.
+export class CrashCapObserver implements vscodelc.ErrorHandler {
+  private inner?: vscodelc.ErrorHandler;
+
+  constructor(private readonly onCappedOut: () => void) {}
+
+  /// Called after the client is constructed to install the real handler
+  /// (the default handler is a method on the client, which doesn't exist
+  /// at the time clientOptions.errorHandler must be set).
+  setInner(handler: vscodelc.ErrorHandler) {
+    this.inner = handler;
+  }
+
+  async error(
+    error: Error,
+    message: Message | undefined,
+    count: number | undefined,
+  ): Promise<vscodelc.ErrorHandlerResult> {
+    return (
+      (await this.inner?.error(error, message, count)) ?? {
+        action: vscodelc.ErrorAction.Continue,
+      }
+    );
+  }
+
+  async closed(): Promise<vscodelc.CloseHandlerResult> {
+    const result = (await this.inner?.closed()) ?? {
+      action: vscodelc.CloseAction.DoNotRestart,
+    };
+    if (result.action === vscodelc.CloseAction.DoNotRestart) {
+      this.onCappedOut();
+    }
+    return result;
+  }
+}

--- a/extension/lsp/lsp.ts
+++ b/extension/lsp/lsp.ts
@@ -13,9 +13,9 @@
 
 import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient/node';
-import { Message } from 'vscode-languageserver-protocol';
 
 import * as config from '../utils/config';
+import { CrashCapObserver } from './crashCapObserver';
 import { DisposableContext } from '../utils/disposableContext';
 import { Subject } from 'rxjs';
 import { Logger } from '../logging';
@@ -23,46 +23,6 @@ import { LSPRecorder } from './recorder';
 import { Optional } from '../types';
 import { PythonEnvironmentManager, SDK } from '../pyenv';
 import { SDKStatusBar } from '../statusBar';
-
-/// Wraps the language client's default error handler so we can observe when
-/// the library's crash cap fires (i.e. `closed()` returns `DoNotRestart`).
-/// The library's cap policy is a private decision otherwise — no event
-/// surfaces it — so intercepting the handler is the only way to distinguish
-/// "stopped after crash cap" from "stopped for another reason" in the UI.
-class CrashCapObserver implements vscodelc.ErrorHandler {
-  private inner?: vscodelc.ErrorHandler;
-
-  constructor(private readonly onCappedOut: () => void) {}
-
-  /// Called after the client is constructed to install the real handler
-  /// (the default handler is a method on the client, which doesn't exist
-  /// at the time clientOptions.errorHandler must be set).
-  setInner(handler: vscodelc.ErrorHandler) {
-    this.inner = handler;
-  }
-
-  async error(
-    error: Error,
-    message: Message | undefined,
-    count: number | undefined,
-  ): Promise<vscodelc.ErrorHandlerResult> {
-    return (
-      (await this.inner?.error(error, message, count)) ?? {
-        action: vscodelc.ErrorAction.Continue,
-      }
-    );
-  }
-
-  async closed(): Promise<vscodelc.CloseHandlerResult> {
-    const result = (await this.inner?.closed()) ?? {
-      action: vscodelc.CloseAction.DoNotRestart,
-    };
-    if (result.action === vscodelc.CloseAction.DoNotRestart) {
-      this.onCappedOut();
-    }
-    return result;
-  }
-}
 
 /**
  *  This class manages the LSP clients.


### PR DESCRIPTION
Extract CrashCapObserver from lsp.ts into its own file so it can be unit-tested independently, and add crashCapObserver.test.default.ts covering the observable behaviors:

- Fires onCappedOut exactly when inner.closed() returns DoNotRestart.
- Does not fire on Restart.
- Fires once per DoNotRestart across a realistic sequence (N Restarts followed by a DoNotRestart, mirroring the library's default cap policy).
- Passes error() through to inner and returns its result.
- Safe defaults (DoNotRestart / Continue) when setInner hasn't been called yet.

Runs under the default label; no SDK needed.

The extraction matches the existing pattern in this directory (LSPRecorder lives in its own recorder.ts alongside lsp.ts).

Doesn't cover the higher-level wiring in lsp.ts (that clientOptions actually receives the observer, that onCappedOut is wired to updateLsp, etc.) — an integration test of the crash-cap flow would need a fake SDK fixture, filed as a future improvement.