### PR TITLE
Bump shell-quote to fix CVE-2026-9277 (critical, GHSA-w7jw-789q-3m8p)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "ini": "4.1.1",
         "md5": "2.3.0",
         "rxjs": "7.8.1",
-        "shell-quote": "1.8.1",
+        "shell-quote": "^1.8.4",
         "typescript-memoize": "1.1.1",
         "vscode-languageclient": "^9.0.1"
       },
@@ -6970,10 +6970,13 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ini": "4.1.1",
     "md5": "2.3.0",
     "rxjs": "7.8.1",
-    "shell-quote": "1.8.1",
+    "shell-quote": "^1.8.4",
     "typescript-memoize": "1.1.1",
     "vscode-languageclient": "^9.0.1"
   },


### PR DESCRIPTION
Loosen the shell-quote pin from exact `1.8.1` to `^1.8.4` in package.json so we pick up the fix for the critical `quote()` newline-escape vulnerability. The lockfile-only Dependabot strategy was blocked by the exact pin, so no automatic PR was opened; loosening to `^1.8.4` unblocks both this fix and any future security patches within the 1.x series.

Direct call sites in extension/commands/run.ts and extension/debug/ debug.ts use only the standard string[] and string API surfaces, so no code changes are needed alongside the version bump.