### PR TITLE
test: Veracode SCA visibility check

### DIFF
--- a/.veracode-visibility-test.txt
+++ b/.veracode-visibility-test.txt
@@ -6,3 +6,4 @@ include_repos to just vscode-mojo and set the SCA-on-PR trigger.
 Safe to close/delete once a Veracode SCA check run is confirmed on this PR.
 
 
+

--- a/.veracode-visibility-test.txt
+++ b/.veracode-visibility-test.txt
@@ -5,3 +5,4 @@ include_repos to just vscode-mojo and set the SCA-on-PR trigger.
 
 Safe to close/delete once a Veracode SCA check run is confirmed on this PR.
 
+

--- a/.veracode-visibility-test.txt
+++ b/.veracode-visibility-test.txt
@@ -1,0 +1,6 @@
+Test PR to confirm the Veracode SCA agent scan now fires on pull requests
+against this repo, after modular/veracode PR #12
+(https://github.com/modular/veracode/pull/12) scoped repo_list.yml's
+include_repos to just vscode-mojo and set the SCA-on-PR trigger.
+
+Safe to close/delete once a Veracode SCA check run is confirmed on this PR.

--- a/.veracode-visibility-test.txt
+++ b/.veracode-visibility-test.txt
@@ -4,3 +4,4 @@ against this repo, after modular/veracode PR #12
 include_repos to just vscode-mojo and set the SCA-on-PR trigger.
 
 Safe to close/delete once a Veracode SCA check run is confirmed on this PR.
+


### PR DESCRIPTION
Trivial test PR to confirm the Veracode SCA agent scan now fires on pull requests against this repo, following modular/veracode#12 (scoped repo_list.yml's include_repos to just vscode-mojo). Safe to close once a Veracode SCA check run shows up here.